### PR TITLE
feature: upload de arquivos usando o nome

### DIFF
--- a/pages/api/media.ts
+++ b/pages/api/media.ts
@@ -1,6 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import S3 from "aws-sdk/clients/s3";
-import { randomUUID } from "crypto";
 
 const s3 = new S3({
   apiVersion: "2006-03-01",
@@ -14,10 +13,9 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const extension = (req.query.fileType as string).split("/")[1];
   const contentType = (req.query.fileType as string)
-
-  const Key = `${randomUUID()}.${extension}`;
+  const contentName = (req.query.fileName as string)
+  const Key = contentName;
 
   const s3Params = {
     Bucket: process.env.BUCKET_NAME,
@@ -30,6 +28,7 @@ export default async function handler(
 
   res.status(200).json({
     uploadUrl,
-    key: Key,
+    status: "success",
+    message: `Upload realizado com sucesso!`
   });
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -13,12 +13,12 @@ const Home = () => {
     if (!file) return null;
     // @ts-ignore
     const fileType = encodeURIComponent(file.type);
-    const { data } = await axios.get(`/api/media?fileType=${fileType}`);
-    const { uploadUrl, key } = data;
+     // @ts-ignore
+    const fileName = encodeURIComponent(file.name);
+    const { data } = await axios.get(`/api/media?fileType=${fileType}&fileName=${fileName}`);
+    const { uploadUrl } = data;
 
     await axios.put(uploadUrl, file);
-
-    return key;
   };
 
   const handleSubmit = async (e: ChangeEvent<HTMLFormElement>) => {


### PR DESCRIPTION
The PUT request was being made using the key as a random number with the file extension, now it has changed to use the name of the file as Key. This way, all uploaded files will have their correct name in the s3 bucket, and that's ok because the bucket has versioning enabled